### PR TITLE
Fix WebSocketManager instantiation

### DIFF
--- a/app/src/main/java/org/chaynik/dch/data/SocketConnectorImpl.kt
+++ b/app/src/main/java/org/chaynik/dch/data/SocketConnectorImpl.kt
@@ -1,11 +1,16 @@
 package org.chaynik.dch.data
 
+import android.content.Context
+import kotlinx.coroutines.delay
 import org.chaynik.dch.WebSocketManager
 
-class SocketConnectorImpl : SocketConnector {
+class SocketConnectorImpl(private val context: Context) : SocketConnector {
+
+    private val webSocketManager by lazy { WebSocketManager(context) }
+
     override suspend fun connect(): Boolean {
-        WebSocketManager.connect()
+        webSocketManager.connect()
         delay(3000)
-        return WebSocketManager.isConnected()
+        return webSocketManager.isConnected()
     }
 }

--- a/app/src/main/java/org/chaynik/dch/presentation/settings/SettingsViewModelFactory.kt
+++ b/app/src/main/java/org/chaynik/dch/presentation/settings/SettingsViewModelFactory.kt
@@ -11,7 +11,7 @@ import org.chaynik.dch.domain.usecase.ConnectAndSaveSsidUseCase
 class SettingsViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         val wifiRepo = WifiRepositoryImpl(context)
-        val socketConnector = SocketConnectorImpl()
+        val socketConnector = SocketConnectorImpl(context)
         return SettingsViewModel(
             ConnectAndSaveSsidUseCase(wifiRepo, socketConnector),
             CheckWifiConnectionUseCase(wifiRepo)


### PR DESCRIPTION
## Summary
- fix misuse of `WebSocketManager` in `SocketConnectorImpl`
- pass `Context` to `SocketConnectorImpl` via `SettingsViewModelFactory`

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68647431a5a0832abc2ed5a344e2ccb5